### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "PrunePal Dev",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    }
+  },
+  "postCreateCommand": "corepack enable && corepack prepare yarn@stable --activate",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# prunella
+# Prunella
 
 Developer environment for PrunePal.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # prunella
+
+Developer environment for PrunePal.
+
+## Dev Container
+
+Use the provided dev container to get Node 22 with Yarn Berry preinstalled.
+Open in VS Code and run `yarn install` to get started.
+
+## Local Development
+
+```bash
+docker compose up -d
+```
+
+Run lint and tests with:
+
+```bash
+yarn lint
+yarn test
+```


### PR DESCRIPTION
## Summary
- add dev container configuration for Node 22
- document dev container usage

## Testing
- `yarn lint` *(fails: No project found)*
- `yarn test` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7cd55e4c8326b946feda863d706d

## Summary by Sourcery

Provide a ready-to-use development container and update documentation to streamline local setup

New Features:
- Add dev container configuration for Node 22 with Yarn Berry

Documentation:
- Document dev container usage and local development setup in README