### PR TITLE
fix: add devcontainer base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
   "name": "PrunePal Dev",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-22-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"


### PR DESCRIPTION
## Summary
- specify Node.js 22 base image for dev container

## Testing
- `yarn lint` *(fails: No project found)*
- `yarn test` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7ff86b7883268c53141c1b443371

## Summary by Sourcery

Enhancements:
- Specify Node.js 22 base image in .devcontainer/devcontainer.json to ensure a consistent dev environment