### PR TITLE
Update dev container image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "PrunePal Dev",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-22-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "22"


### PR DESCRIPTION
## Summary
- update devcontainer image to version `1-22-bullseye`

## Testing
- `yarn lint` *(fails: No project found)*
- `yarn test` *(fails: No project found)*
- `docker pull mcr.microsoft.com/devcontainers/typescript-node:1-22-bullseye` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c849e962c832685b689e5e2aafa04

## Summary by Sourcery

Enhancements:
- Bump devcontainer base image to mcr.microsoft.com/devcontainers/typescript-node:1-22-bullseye